### PR TITLE
fix: wrap event type in backticks to avoid invalid input errors

### DIFF
--- a/nerdlets/util/graphqlbuilders.js
+++ b/nerdlets/util/graphqlbuilders.js
@@ -17,7 +17,7 @@ export function buildAttributeQueries(selectedAccountID, eventType) {
   const query = `{
     actor {
       query${selectedAccountID}: account(id: ${selectedAccountID}) {
-        nrql(query: "SELECT keyset() FROM ${eventType} since 1 week ago", timeout: 200) {
+        nrql(query: "SELECT keyset() FROM \`${eventType}\` since 1 week ago", timeout: 200) {
           results
         }
       }


### PR DESCRIPTION
This change wraps the `eventType` argument in backticks to avoid NRQL errors if the event name contains invalid characters (ex. `:`) that need to be wrapped. 